### PR TITLE
refactor(tests): 修改日志信息格式

### DIFF
--- a/tests/test_for_electro_thermal_2d.cpp
+++ b/tests/test_for_electro_thermal_2d.cpp
@@ -151,13 +151,13 @@ TEST_F(Coupled2DValidationTest, CompareAgainstVtuResult) {
         }
     }
 
-    logger.info("Successfully matched and compared {} nodes based on coordinates.", matched_nodes);
+    logger.info("Successfully matched and compared ", matched_nodes," nodes based on coordinates.");
     if(matched_nodes < problem->getMesh().getNodes().size()){
         logger.warn("Could not find a match for {} nodes from the simulation mesh in the reference VTU file.", problem->getMesh().getNodes().size() - matched_nodes);
     }
 
-    logger.info("Maximum temperature difference: {} K", max_temp_diff);
-    logger.info("Maximum voltage difference: {} V", max_volt_diff);
+    logger.info("Maximum temperature difference: ", max_temp_diff, " K");
+    logger.info("Maximum voltage difference: ",max_volt_diff," V");
 
     // Assert that the maximum differences are within an acceptable tolerance
     ASSERT_LT(max_temp_diff, 1e-5);

--- a/tests/test_for_electro_thermal_3d.cpp
+++ b/tests/test_for_electro_thermal_3d.cpp
@@ -154,9 +154,9 @@ TEST_F(Coupled3DValidationTest, CompareAgainstVtuResult) {
         }
     }
 
-    logger.info("Successfully matched and compared {} nodes based on coordinates.", matched_nodes);
-    logger.info("Maximum temperature difference: {} K", max_temp_diff);
-    logger.info("Maximum voltage difference: {} V", max_volt_diff);
+    logger.info("Successfully matched and compared ", matched_nodes," nodes based on coordinates.");
+    logger.info("Maximum temperature difference: ", max_temp_diff, " K");
+    logger.info("Maximum voltage difference: ",max_volt_diff," V");
 
     // Assert that the maximum differences are within an acceptable tolerance
     ASSERT_LT(max_temp_diff, 1);


### PR DESCRIPTION
- 在 electro_thermal_2d 和 electro_thermal_3d 测试中调整了日志信息的格式
- 将格式化字符串中的 {} 替换为逗号分隔的参数- 优化了日志信息的可读性和一致性